### PR TITLE
Track copied gem effect IDs when socketing so transferred activities …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # packs/**/*.old
 # packs/**/*.bak
+
+AGENTS.md

--- a/css/actor-gem-badges.css
+++ b/css/actor-gem-badges.css
@@ -97,6 +97,24 @@
   order: initial;
 }
 
+.sc-sockets-entry-name-with-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.sc-sockets-entry-badges {
+  margin-top: 0.1rem;
+}
+
+.dnd5e.sheet.item .sc-sockets-entry-badges .gem img,
+.dnd5e2.sheet.item .sc-sockets-entry-badges .gem img,
+.tidy5e-sheet .sc-sockets-entry-badges .gem img {
+  width: 18px;
+  height: 18px;
+}
+
 /* Positioning for activity badges on item sheets and activity choices */
 .dnd5e2.sheet.item .activities .activity .icon,
 .dnd5e.sheet.item .activities .activity .icon,

--- a/docs/v13-v14-smoke-tests.md
+++ b/docs/v13-v14-smoke-tests.md
@@ -34,6 +34,8 @@ Use the same world content on both targets:
 - Confirm the host item receives the expected effects.
 - Socket a gem that grants activities.
 - Confirm the host item activities appear and activity badges render.
+- Socket a gem with an activity that applies one of the gem's own non-transfer effects.
+- Confirm the copied activity applies the copied host effect, not the original gem effect ID.
 - Remove the gem and confirm transferred effects and activities are removed.
 
 ## 5. Tidy Integration

--- a/scripts/core/services/ActivityTransferService.js
+++ b/scripts/core/services/ActivityTransferService.js
@@ -6,6 +6,7 @@ export class ActivityTransferService {
   static UPDATE_OPTION_SKIP_RECONCILE = "skipActivityReconcile";
   static UPDATE_OPTION_SKIP_REMOVE_EXISTING = "skipRemoveExisting";
   static UPDATE_OPTION_EXTRA_UPDATE_DATA = "extraUpdateData";
+  static UPDATE_OPTION_EFFECT_ID_MAP = "effectIdMap";
 
   static async applyFromGem(hostItem, slotIndex, gemItem, options = {}) {
     hostItem = ItemSheetSync.resolve(hostItem);
@@ -14,7 +15,7 @@ export class ActivityTransferService {
       return;
     }
 
-    const { extraUpdateData, updateOptions } = ActivityTransferService.#splitUpdateOptions(options);
+    const { extraUpdateData, updateOptions, effectIdMap } = ActivityTransferService.#splitUpdateOptions(options);
 
     if (!options?.[Constants.MODULE_ID]?.[ActivityTransferService.UPDATE_OPTION_SKIP_REMOVE_EXISTING]) {
       await ActivityTransferService.removeForSlot(hostItem, slotIndex, options);
@@ -50,6 +51,7 @@ export class ActivityTransferService {
 
       const createData = foundry.utils.deepClone(original);
       delete createData._id;
+      ActivityTransferService.#remapActivityEffectReferences(createData, effectIdMap);
       createData.flags ??= {};
       createData.flags[Constants.MODULE_ID] ??= {};
       createData.flags[Constants.MODULE_ID][Constants.FLAG_SOURCE_GEM] = {
@@ -391,12 +393,16 @@ export class ActivityTransferService {
     const extraUpdateData = (moduleOptions && typeof moduleOptions === "object")
       ? foundry.utils.deepClone(moduleOptions[ActivityTransferService.UPDATE_OPTION_EXTRA_UPDATE_DATA] ?? {})
       : {};
+    const effectIdMap = ActivityTransferService.#normalizeEffectIdMap(
+      moduleOptions?.[ActivityTransferService.UPDATE_OPTION_EFFECT_ID_MAP]
+    );
 
     const updateOptions = { ...options };
     if (moduleOptions && typeof moduleOptions === "object") {
       const nextModuleOptions = { ...moduleOptions };
       delete nextModuleOptions[ActivityTransferService.UPDATE_OPTION_EXTRA_UPDATE_DATA];
       delete nextModuleOptions[ActivityTransferService.UPDATE_OPTION_SKIP_REMOVE_EXISTING];
+      delete nextModuleOptions[ActivityTransferService.UPDATE_OPTION_EFFECT_ID_MAP];
       if (Object.keys(nextModuleOptions).length) {
         updateOptions[Constants.MODULE_ID] = nextModuleOptions;
       } else {
@@ -404,7 +410,41 @@ export class ActivityTransferService {
       }
     }
 
-    return { extraUpdateData, updateOptions };
+    return { extraUpdateData, updateOptions, effectIdMap };
+  }
+
+  static #normalizeEffectIdMap(value) {
+    if (value instanceof Map) {
+      return value;
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return new Map();
+    }
+    return new Map(
+      Object.entries(value)
+        .map(([sourceId, createdId]) => [String(sourceId), String(createdId)])
+        .filter(([sourceId, createdId]) => sourceId && createdId)
+    );
+  }
+
+  static #remapActivityEffectReferences(activityData, effectIdMap) {
+    if (!effectIdMap?.size || !Array.isArray(activityData?.effects)) {
+      return;
+    }
+    activityData.effects = activityData.effects.map((effectRef) => {
+      if (!effectRef || typeof effectRef !== "object") {
+        return effectRef;
+      }
+      const sourceId = String(effectRef._id ?? "").trim();
+      const createdId = effectIdMap.get(sourceId);
+      if (!createdId) {
+        return effectRef;
+      }
+      return {
+        ...foundry.utils.deepClone(effectRef),
+        _id: createdId
+      };
+    });
   }
 
   static #sanitizeTransferredActivityPayload(payload, hostItem) {

--- a/scripts/core/services/EffectService.js
+++ b/scripts/core/services/EffectService.js
@@ -5,8 +5,10 @@ export class EffectService {
   static async applyGemEffects(hostItem, slotIndex, gemItem, options = {}) {
     const src = gemItem.effects?.contents ?? [];
     if (!src.length) {
-      return;
+      return new Map();
     }
+    const activityEffectIds = EffectService.#getActivityEffectIds(gemItem);
+    const sourceEffectIds = src.map(eff => eff.id);
     const toCreate = src.map(eff => {
       const data = eff.toObject();
       delete data._id;
@@ -21,7 +23,7 @@ export class EffectService {
         data.flags.dnd5e ??= {};
         data.flags.dnd5e.enchantmentProfile ??= eff.id;
       } else {
-        data.transfer = true;
+        data.transfer = !activityEffectIds.has(eff.id);
         data.origin = hostItem.uuid;
       }
       data.flags ??= {};
@@ -33,7 +35,8 @@ export class EffectService {
       };
       return data;
     });
-    await hostItem.createEmbeddedDocuments("ActiveEffect", toCreate, options);
+    const createdEffects = await hostItem.createEmbeddedDocuments("ActiveEffect", toCreate, options);
+    return EffectService.#buildCreatedEffectIdMap(sourceEffectIds, createdEffects);
   }
 
   static async removeGemEffects(hostItem, slotIndex, options = {}) {
@@ -48,6 +51,30 @@ export class EffectService {
 
   static #isEnchantmentEffect(effectData) {
     return effectData?.type === "enchantment" || effectData?.flags?.dnd5e?.type === "enchantment";
+  }
+
+  static #getActivityEffectIds(item) {
+    const ids = new Set();
+    for (const activity of item?.system?.activities?.contents ?? []) {
+      const effects = activity?.toObject?.()?.effects;
+      if (!Array.isArray(effects)) continue;
+      for (const effect of effects) {
+        const id = String(effect?._id ?? "").trim();
+        if (id) ids.add(id);
+      }
+    }
+    return ids;
+  }
+
+  static #buildCreatedEffectIdMap(sourceEffectIds, createdEffects) {
+    const map = new Map();
+    for (const [index, sourceId] of sourceEffectIds.entries()) {
+      const createdId = createdEffects?.[index]?.id ?? createdEffects?.[index]?._id ?? null;
+      if (sourceId && createdId) {
+        map.set(sourceId, createdId);
+      }
+    }
+    return map;
   }
 
   static #getAppliedEnchantmentOrigin(effectData, effect, gemItem, hostItem) {

--- a/scripts/core/services/SocketService.js
+++ b/scripts/core/services/SocketService.js
@@ -145,12 +145,13 @@ export class SocketService {
     slots[idx] = SocketSlot.fillFromGem(slots[idx], gemItem, snap, idx);
     ItemResolver.normalizeSocketSlots(slots);
 
-    await EffectService.applyGemEffects(hostItem, idx, gemItem, noRender);
+    const effectIdMap = await EffectService.applyGemEffects(hostItem, idx, gemItem, noRender);
     await ActivityTransferService.applyFromGem(hostItem, idx, gemItem, {
       ...noRender,
       [Constants.MODULE_ID]: {
         ...(noRender?.[Constants.MODULE_ID] ?? {}),
         [ActivityTransferService.UPDATE_OPTION_SKIP_REMOVE_EXISTING]: true,
+        [ActivityTransferService.UPDATE_OPTION_EFFECT_ID_MAP]: effectIdMap,
         [ActivityTransferService.UPDATE_OPTION_EXTRA_UPDATE_DATA]: {
           [`flags.${Constants.MODULE_ID}.${Constants.FLAGS.sockets}`]: slots
         }

--- a/scripts/core/ui/ItemActivityBadges.js
+++ b/scripts/core/ui/ItemActivityBadges.js
@@ -1,11 +1,16 @@
 import { Constants } from "../Constants.js";
 
-const BADGE_CLASS = "sc-sockets-activity-badge";
+const LEGACY_ACTIVITY_BADGE_CLASS = "sc-sockets-activity-badge";
+const BADGE_HOST_CLASS = "sc-sockets-entry-name-with-badges";
+const BADGE_WRAPPER_CLASS = "sc-sockets-entry-badges";
+const OBSERVER_DEBOUNCE_MS = 50;
 
 const SOCKET_FLAG = Constants.FLAGS?.sockets ?? "sockets";
+const MODULE_MUTATION_CLASSES = [BADGE_WRAPPER_CLASS];
 
 export class ItemActivityBadges {
   static #handlers = new Map();
+  static #observerState = new WeakMap();
 
   static activate() {
     this.deactivate();
@@ -37,19 +42,43 @@ export class ItemActivityBadges {
     const root = this.#rootOf(html);
     if (!root) return;
 
+    this.#renderBadges(root, item);
+    this.#observeLazyTidyContent(root, item);
+  }
+
+  static #renderBadges(root, item) {
+    root.querySelectorAll(`.${LEGACY_ACTIVITY_BADGE_CLASS}`).forEach((node) => node.remove());
+
     const activities = item.system?.activities;
-    if (!activities?.size) return;
+    const effects = item.effects;
 
     const activityMap = this.#buildActivityMap(item);
-    if (!activityMap.size) {
-      this.#clearBadges(root);
-      return;
+    const effectMap = this.#buildEffectMap(item);
+    const renderedHosts = new Set();
+
+    for (const activity of this.#entries(activities)) {
+      const meta = activityMap.get(activity.id);
+      if (!meta) continue;
+
+      const host = this.#findActivityBadgeHost(root, activity.id);
+      if (!host) continue;
+
+      renderedHosts.add(host);
+      this.#syncBadges(host, [meta]);
     }
 
-    for (const activity of activities) {
-      const node = this.#findActivityIcon(root, activity.id);
-      this.#decorateIcon(node, activity, activityMap.get(activity.id));
+    for (const effect of this.#entries(effects)) {
+      const meta = effectMap.get(effect.id);
+      if (!meta) continue;
+
+      const host = this.#findEffectBadgeHost(root, effect.id);
+      if (!host) continue;
+
+      renderedHosts.add(host);
+      this.#syncBadges(host, [meta]);
     }
+
+    this.#clearStaleBadges(root, renderedHosts);
   }
 
   static #onRenderActivityChoice(app, html) {
@@ -70,7 +99,7 @@ export class ItemActivityBadges {
       const activity = activities.get?.(id) ?? activities.find?.((a) => a.id === id);
       if (!activity) return;
       const icon = button.querySelector(".icon");
-      this.#decorateIcon(icon, activity, activityMap.get(activity.id));
+      this.#decorateChoiceIcon(icon, activity, activityMap.get(activity.id));
     });
   }
 
@@ -81,24 +110,73 @@ export class ItemActivityBadges {
     return null;
   }
 
-  static #clearBadges(root) {
-    root.querySelectorAll(`.${BADGE_CLASS}`).forEach((el) => el.remove());
+  static #entries(collection) {
+    if (!collection) return [];
+    if (typeof collection.values === "function") return Array.from(collection.values());
+    if (Array.isArray(collection)) return collection;
+    if (typeof collection === "object") {
+      return Object.values(collection).filter((entry) => entry && typeof entry === "object");
+    }
+    return [];
   }
 
-  static #findActivityIcon(root, activityId) {
+  static #findActivityBadgeHost(root, activityId) {
     if (!root || !activityId) return null;
 
+    const escapedId = this.#escapeSelectorValue(activityId);
+    if (!escapedId) return null;
+
     const selectors = [
-      `.activity.card[data-activity-id="${activityId}"] .icon`,
-      `[data-activity-id="${activityId}"] .icon`
+      `.item.activity[data-activity-id="${escapedId}"] .item-name.activity-name .name.name-stacked`,
+      `.activity-row[data-activity-id="${escapedId}"] .item-name.activity-name .name.name-stacked`,
+      `[data-activity-id="${escapedId}"] .item-name.activity-name .name.name-stacked`,
+      `.tidy-table-row.activity[data-activity-id="${escapedId}"] .tidy-table-cell.primary .item-name .cell-text`,
+      `[data-activity-id="${escapedId}"] .tidy-table-cell.primary .item-name .cell-text`,
+      `.activity.card[data-activity-id="${escapedId}"] .name`,
+      `[data-activity-id="${escapedId}"] .item-name .cell-text`,
+      `[data-activity-id="${escapedId}"] .cell-text`
     ];
 
+    return this.#findFirst(root, selectors);
+  }
+
+  static #findEffectBadgeHost(root, effectId) {
+    if (!root || !effectId) return null;
+
+    const escapedId = this.#escapeSelectorValue(effectId);
+    if (!escapedId) return null;
+
+    const selectors = [
+      `.item.effect[data-effect-id="${escapedId}"] .item-name.effect-name .name.name-stacked`,
+      `.activity-row[data-effect-id="${escapedId}"] .item-name.effect-name .name.name-stacked`,
+      `[data-effect-id="${escapedId}"] .item-name.effect-name .name.name-stacked`,
+      `.item.effect[data-effect-id="${escapedId}"] .item-name.effect-name .truncate`,
+      `[data-effect-id="${escapedId}"] .item-name.effect-name .truncate`,
+      `.item.effect[data-effect-id="${escapedId}"] .item-name.effect-name`,
+      `[data-effect-id="${escapedId}"] .item-name.effect-name`,
+      `[data-effect-id="${escapedId}"] .tidy-table-cell.primary .item-name .cell-text`,
+      `[data-effect-id="${escapedId}"] .item-name .cell-text`,
+      `[data-effect-id="${escapedId}"] .cell-text`,
+      `[data-effect-id="${escapedId}"] .cell-name`
+    ];
+
+    return this.#findFirst(root, selectors);
+  }
+
+  static #findFirst(root, selectors) {
     for (const selector of selectors) {
       const node = root.querySelector(selector);
-      if (node) return node;
+      if (node instanceof HTMLElement) return node;
     }
 
     return null;
+  }
+
+  static #escapeSelectorValue(value) {
+    const text = String(value ?? "").trim();
+    if (!text) return "";
+    if (globalThis.CSS?.escape) return globalThis.CSS.escape(text);
+    return text.replace(/["\\]/g, "\\$&");
   }
 
   static #buildActivityMap(item) {
@@ -126,10 +204,10 @@ export class ItemActivityBadges {
       }
     }
 
-    for (const activity of activities ?? []) {
+    for (const activity of this.#entries(activities)) {
       if (!activity?.id || map.has(activity.id)) continue;
 
-      const sourceGem = activity?.flags?.[Constants.MODULE_ID]?.[Constants.FLAG_SOURCE_GEM];
+      const sourceGem = this.#getModuleFlags(activity)[Constants.FLAG_SOURCE_GEM];
       if (!sourceGem) continue;
 
       const slotKey = String(sourceGem.slot);
@@ -146,9 +224,173 @@ export class ItemActivityBadges {
     return map;
   }
 
-  static #decorateIcon(node, activity, meta) {
+  static #buildEffectMap(item) {
+    const sockets = item.getFlag(Constants.MODULE_ID, SOCKET_FLAG) ?? [];
+    const map = new Map();
+
+    for (const effect of this.#entries(item.effects)) {
+      if (!effect?.id) continue;
+
+      const sourceGem = this.#getModuleFlags(effect)[Constants.FLAG_SOURCE_GEM];
+      if (!sourceGem) continue;
+
+      const slotKey = String(sourceGem.slot);
+      const slotIndex = Number(sourceGem.slot);
+      const socketInfo = Array.isArray(sockets) ? sockets[slotIndex] : sockets?.[slotKey];
+      const socketGem = socketInfo?.gem ?? {};
+
+      map.set(effect.id, {
+        slot: slotKey,
+        gemImg: socketGem.img ?? socketInfo?.img ?? Constants.SOCKET_SLOT_IMG,
+        gemName: socketGem.name ?? socketInfo?.name ?? item.name,
+        sourceId: sourceGem.sourceId ?? null
+      });
+    }
+
+    return map;
+  }
+
+  static #getModuleFlags(documentLike) {
+    if (!documentLike || typeof documentLike !== "object") return {};
+
+    const directFlags = documentLike.flags?.[Constants.MODULE_ID];
+    if (directFlags && typeof directFlags === "object") {
+      return directFlags;
+    }
+
+    const sourceFlags = documentLike.toObject?.()?.flags?.[Constants.MODULE_ID];
+    return sourceFlags && typeof sourceFlags === "object" ? sourceFlags : {};
+  }
+
+  static #syncBadges(host, badges) {
+    host.classList.add(BADGE_HOST_CLASS);
+
+    const signature = this.#buildBadgeSignature(badges);
+    const existing = this.#findBadgeWrapper(host);
+    if (existing?.dataset.scSocketsBadgeSignature === signature) return;
+
+    this.#removeBadgeWrappers(host);
+    this.#injectBadges(host, badges, signature);
+  }
+
+  static #injectBadges(host, badges, signature) {
+    const wrapper = document.createElement(host.matches("a, button, span") ? "span" : "div");
+    wrapper.className = `${BADGE_WRAPPER_CLASS} sc-sockets-badges sc-sockets-badges-inline`;
+    wrapper.dataset.scSocketsBadgeSignature = signature;
+
+    for (const entry of badges) {
+      const badge = document.createElement("span");
+      badge.className = "gem";
+
+      const label = String(entry?.gemName || "Socketed Gem").trim();
+      if (label) {
+        badge.dataset.tooltip = label;
+        badge.dataset.tooltipDirection = "LEFT";
+      }
+
+      const image = document.createElement("img");
+      image.src = String(entry?.gemImg || "").trim() || Constants.SOCKET_SLOT_IMG;
+      image.alt = label;
+      image.draggable = false;
+
+      badge.append(image);
+      wrapper.append(badge);
+    }
+
+    host.append(wrapper);
+  }
+
+  static #buildBadgeSignature(badges) {
+    return badges
+      .map((entry) => [
+        String(entry?.gemName || "Socketed Gem").trim(),
+        String(entry?.gemImg || "").trim(),
+        String(entry?.slot ?? "").trim()
+      ].join("|"))
+      .join(";");
+  }
+
+  static #findBadgeWrapper(host) {
+    return Array.from(host.children).find((child) => (
+      child instanceof HTMLElement
+      && child.classList.contains(BADGE_WRAPPER_CLASS)
+    )) ?? null;
+  }
+
+  static #removeBadgeWrappers(host) {
+    Array.from(host.children)
+      .filter((child) => child instanceof HTMLElement && child.classList.contains(BADGE_WRAPPER_CLASS))
+      .forEach((node) => node.remove());
+  }
+
+  static #clearStaleBadges(root, renderedHosts) {
+    root.querySelectorAll(`.${BADGE_WRAPPER_CLASS}`).forEach((wrapper) => {
+      const host = wrapper.parentElement;
+      if (host && renderedHosts.has(host)) return;
+      wrapper.remove();
+    });
+
+    root.querySelectorAll(`.${BADGE_HOST_CLASS}`).forEach((host) => {
+      if (this.#findBadgeWrapper(host)) return;
+      host.classList.remove(BADGE_HOST_CLASS);
+    });
+  }
+
+  static #observeLazyTidyContent(root, item) {
+    if (!(root instanceof HTMLElement)) return;
+    this.#disconnectObserver(root);
+
+    if (!this.#isTidyRoot(root)) return;
+
+    const state = { timer: null };
+    const observer = new MutationObserver((mutations) => {
+      if (mutations.every((mutation) => this.#isOwnBadgeMutation(mutation))) return;
+
+      if (state.timer) clearTimeout(state.timer);
+      state.timer = setTimeout(() => {
+        state.timer = null;
+        if (!root.isConnected) {
+          this.#disconnectObserver(root);
+          return;
+        }
+        this.#renderBadges(root, item);
+      }, OBSERVER_DEBOUNCE_MS);
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    this.#observerState.set(root, { observer, state });
+  }
+
+  static #disconnectObserver(root) {
+    const existing = this.#observerState.get(root);
+    if (!existing) return;
+
+    existing.observer.disconnect();
+    if (existing.state.timer) clearTimeout(existing.state.timer);
+    this.#observerState.delete(root);
+  }
+
+  static #isTidyRoot(root) {
+    return root.matches?.(".tidy5e-sheet, .tidy-tab, .tidy-table, [data-tidy-sheet-part]")
+      || Boolean(root.querySelector(".tidy5e-sheet, .tidy-tab, .tidy-table, [data-tidy-sheet-part]"));
+  }
+
+  static #isOwnBadgeMutation(mutation) {
+    const nodes = [...mutation.addedNodes, ...mutation.removedNodes];
+    if (!nodes.length) return false;
+
+    return nodes.every((node) => (
+      node instanceof HTMLElement
+      && MODULE_MUTATION_CLASSES.some((className) => (
+        node.classList.contains(className)
+        || Boolean(node.closest?.(`.${className}`))
+      ))
+    ));
+  }
+
+  static #decorateChoiceIcon(node, activity, meta) {
     if (!node) return;
-    node.querySelector(`.${BADGE_CLASS}`)?.remove();
+    node.querySelector(`.${LEGACY_ACTIVITY_BADGE_CLASS}`)?.remove();
 
     if (!meta) return;
 
@@ -160,7 +402,7 @@ export class ItemActivityBadges {
     }
 
     const badge = document.createElement("div");
-    badge.className = BADGE_CLASS;
+    badge.className = LEGACY_ACTIVITY_BADGE_CLASS;
     badge.dataset.tooltip = label;
     badge.dataset.tooltipDirection = "LEFT";
 


### PR DESCRIPTION
Track copied gem effect IDs when socketing so transferred activities reference the host item's copied effects instead of the original gem effects.

Keep activity-owned effects from transferring directly, pass the source-to-created effect map through the socket flow, and render gem source badges on item activities and active effects.
